### PR TITLE
Account wide AMI public block

### DIFF
--- a/src/regional/account_setup/lambda_handler.py
+++ b/src/regional/account_setup/lambda_handler.py
@@ -61,6 +61,9 @@ def handler(event: Dict[str, Any], context: LambdaContext) -> None:
     logger.info(f"Enabling snapshot block public access in {region_name} in {account_id}")
     ec2.enable_snapshot_block_public_access()
 
+    logger.info(f"Enabling AMI block public access in {region_name} in {account_id}")
+    ec2.enable_ami_block_public_access()
+
     logger.info(f"Setting default ECS settings in {region_name} in {account_id}")
     ecs = ECS(assumed_session, region_name)
     ecs.put_account_setting_default()

--- a/src/regional/account_setup/resources/ec2.py
+++ b/src/regional/account_setup/resources/ec2.py
@@ -110,3 +110,9 @@ class EC2:
             self.client.enable_snapshot_block_public_access(State="block-all-sharing")
         except botocore.exceptions.ClientError:
             logger.exception(f"Unable to enable snapshot block public access in {self.region}")
+
+    def enable_ami_block_public_access(self) -> None:
+        try:
+            self.client.enable_image_block_public_access(ImageBlockPublicAccessState="block-all-sharing")
+        except botocore.exceptions.ClientError:
+            logger.exception(f"Unable to enable AMI block public access in {self.region_name}")

--- a/src/regional/account_setup/resources/ec2.py
+++ b/src/regional/account_setup/resources/ec2.py
@@ -113,6 +113,6 @@ class EC2:
 
     def enable_ami_block_public_access(self) -> None:
         try:
-            self.client.enable_image_block_public_access(ImageBlockPublicAccessState="block-all-sharing")
+            self.client.enable_image_block_public_access(ImageBlockPublicAccessState="block-new-sharing")
         except botocore.exceptions.ClientError:
             logger.exception(f"Unable to enable AMI block public access in {self.region_name}")


### PR DESCRIPTION
_Issue:_ #10 

_Description of changes:_ add function to enable block public access for AMIs.

_References_:
- [AWS Docs - Enable block public access for AMIs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/manage-block-public-access-for-amis.html#enable-block-public-access-for-amis)
- [Boto3 Docs - enable_image_block_public_access](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2/client/enable_image_block_public_access.html)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
